### PR TITLE
Fix the issue with temporal features notebook

### DIFF
--- a/notebooks/04 MF model plus temporal-features.ipynb
+++ b/notebooks/04 MF model plus temporal-features.ipynb
@@ -133,7 +133,7 @@
    "outputs": [],
    "source": [
     "def total_variation(array):\n",
-    "    return torch.sum(torch.abs(array[:, :-1] - array[:, 1:]))"
+    "    return torch.sum(torch.abs(array[:-1, :] - array[1:, :]))"
    ]
   },
   {


### PR DESCRIPTION
The first dimension of the temporal bias embedding is the dimension for the rating rank and the second dimension is for the latent representation of the ranking. Hence you want to exchange the order of indices in the function `total_variation`.